### PR TITLE
Expand channels to array & fix irccat version/release/tag prefix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ LABEL org.label-schema.build-date=${BUILD_DATE} \
       org.metabrainz.based-on-image="metabrainz/consul-template-base:${CT_VERSION}" \
       org.metabrainz.irccat.version=${IRCCAT_VERSION}
 
-RUN curl -L -o /usr/local/bin/irccat -S https://github.com/irccloud/irccat/releases/download/v${IRCCAT_VERSION}/linux_amd64_irccat && \
+RUN curl -L -o /usr/local/bin/irccat -S https://github.com/irccloud/irccat/releases/download/${IRCCAT_VERSION}/linux_amd64_irccat && \
     chmod 755 /usr/local/bin/irccat
 
 RUN apt-get update && \

--- a/README.md
+++ b/README.md
@@ -5,6 +5,26 @@ Dockerize [IRCCat](https://github.com/irccloud/irccat) with consul-template for 
 * [Docker image](https://hub.docker.com/r/metabrainz/irccat)
 * [Issue tracker](https://tickets.metabrainz.org/issues/?jql=project=OTHER+AND+component=BrainzGit)
 
+## Consul irccat JSON config
+
+The only difference is about `channels` key which is expected to be a
+semi-colon delimited list in a single string rather than an array of
+strings. This is required because consul stores all KV data as strings.
+
+Example:
+
+```
+    "channels": "#metabrainz;#musicbrainz",
+```
+
+will be rewritten into:
+
+```
+    "channels": ["#metabrainz", "#musicbrainz"],
+```
+
+
 ## Building and deploying image
 
+Make sure the Docker daemon is running and you are logged in Docker Hub.
 Use `push.sh` script.

--- a/docker/irccat.json.ctmpl
+++ b/docker/irccat.json.ctmpl
@@ -1,1 +1,1 @@
-{{ tree "docker-server-configs/services/irccat.json" | explode | toJSONPretty }}
+{{ tree "docker-server-configs/services/irccat.json" | explode | toJSONPretty | regexReplaceAll "(\"channels\"): (\"[^\"]*\")," "$1: [$2]," | regexReplaceAll "(\"channels\": .+);" "$1\", \"" }}

--- a/push.sh
+++ b/push.sh
@@ -6,7 +6,7 @@
 # Usage:
 #   $ ./push.sh [version]
 
-version=${1:-0.4.1}
+version=${1:-v0.4.1}
 
 cd `dirname "${BASH_SOURCE[0]}"`
 docker build \

--- a/push.sh
+++ b/push.sh
@@ -6,6 +6,8 @@
 # Usage:
 #   $ ./push.sh [version]
 
+set -e
+
 version=${1:-v0.4.1}
 
 cd `dirname "${BASH_SOURCE[0]}"`


### PR DESCRIPTION
1. Expand channels to array to work around Consul limitation,
2. Fix irccat version/release/tag missing v prefix 